### PR TITLE
Move wiremock from dependencies to dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,6 @@ serde = "1.0.130"
 serde_json = "1.0.69"
 serde_path_to_error = "0.1.5"
 tokio = { version = "1.13.0", features = ["rt-multi-thread", "macros"] }
+
+[dev-dependencies]
 wiremock = "0.5.8"


### PR DESCRIPTION
Because it's only used at tests.
