### PR TITLE
Remove binary feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,17 +16,8 @@ reqwest = { version = "0.11.6" }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.69"
 serde_path_to_error = "0.1.5"
-structopt = { version = "0.3.25", optional = true }
-tokio = { version = "1.13.0", features = ["rt-multi-thread", "macros"], optional = true }
-
-[dev-dependencies]
 structopt = "0.3.25"
-wiremock = "0.5.8"
 tokio = { version = "1.13.0", features = ["rt-multi-thread", "macros"] }
 
-[features]
-binary = ["structopt", "tokio"]
-
-[[bin]]
-name = "imgurian"
-required-features = ["binary"]
+[dev-dependencies]
+wiremock = "0.5.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,7 @@
 pub mod client;
+pub mod commands;
 pub mod error;
 pub mod models;
+pub mod opt;
 pub mod request_builders;
 pub mod result;
-
-#[cfg(feature = "binary")]
-pub mod commands;
-
-#[cfg(feature = "binary")]
-pub mod opt;


### PR DESCRIPTION
because it's inconvenience for binary users to add --features binary option on cargo install...
